### PR TITLE
Open links in rendered Markdown in the browser

### DIFF
--- a/lib/src/main/java/com/mittsu/markedview/MarkedView.java
+++ b/lib/src/main/java/com/mittsu/markedview/MarkedView.java
@@ -2,10 +2,14 @@ package com.mittsu.markedview;
 
 import android.annotation.SuppressLint;
 import android.annotation.TargetApi;
+import android.content.ActivityNotFoundException;
 import android.content.Context;
+import android.content.Intent;
+import android.net.Uri;
 import android.os.Build;
 import android.util.AttributeSet;
 import android.util.Base64;
+import android.webkit.WebResourceRequest;
 import android.webkit.WebSettings;
 import android.webkit.WebView;
 import android.webkit.WebViewClient;
@@ -57,6 +61,34 @@ public final class MarkedView extends WebView {
                 super.onPageFinished(view, url);
                 sendScriptAction();
                 chStyle();
+            }
+
+            @Override
+            public boolean shouldOverrideUrlLoading(WebView view, WebResourceRequest request) {
+                return openExternalLink(view, request.getUrl());
+            }
+
+            @Override
+            @SuppressWarnings("deprecation")
+            public boolean shouldOverrideUrlLoading(WebView view, String url) {
+                return openExternalLink(view, Uri.parse(url));
+            }
+
+            private boolean openExternalLink(WebView view, Uri uri) {
+                String scheme = uri.getScheme();
+                if (scheme == null) {
+                    return false;
+                }
+                scheme = scheme.toLowerCase();
+                if (!scheme.equals("http") && !scheme.equals("https") && !scheme.equals("mailto")) {
+                    return false;
+                }
+                try {
+                    view.getContext().startActivity(new Intent(Intent.ACTION_VIEW, uri));
+                    return true;
+                } catch (ActivityNotFoundException e) {
+                    return false;
+                }
             }
         });
 


### PR DESCRIPTION
The `MarkedView` client only handled `onPageFinished`, so a link tapped inside the rendered Markdown loaded in the preview itself and replaced the document. The existing comment in `init` already noted that the default browser is not called.

This adds `shouldOverrideUrlLoading` (both the `WebResourceRequest` signature and the older string one so it works on older devices). `http`, `https` and `mailto` links open through `Intent.ACTION_VIEW`, so the preview stays put and the link opens in the browser or mail app. The initial `file://` asset load and same page anchors are left to the WebView. If no app can handle the link it is ignored rather than throwing.

Closes #67
